### PR TITLE
Annotate ExtensionSlotReact component

### DIFF
--- a/packages/esm-extension-manager/src/extension-slot-react.component.tsx
+++ b/packages/esm-extension-manager/src/extension-slot-react.component.tsx
@@ -9,10 +9,6 @@ export interface ExtensionSlotReactProps {
   children?: ReactNode;
 }
 
-interface CancelLoading {
-  (): void;
-}
-
 interface ExtensionContextData {
   extensionSlotName: string;
   extensionName: string;
@@ -23,7 +19,7 @@ const ExtensionContext = React.createContext<ExtensionContextData>({
   extensionName: "",
 });
 
-export const ExtensionSlotReact = ({
+export const ExtensionSlotReact: React.FC = ({
   extensionSlotName,
   children,
 }: ExtensionSlotReactProps) => {

--- a/packages/esm-extension-manager/src/extension-slot-react.component.tsx
+++ b/packages/esm-extension-manager/src/extension-slot-react.component.tsx
@@ -19,7 +19,7 @@ const ExtensionContext = React.createContext<ExtensionContextData>({
   extensionName: "",
 });
 
-export const ExtensionSlotReact: React.FC = ({
+export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   extensionSlotName,
   children,
 }: ExtensionSlotReactProps) => {


### PR DESCRIPTION
Adds type annotation to `ExtensionSlotReact` and deletes an unused interface definition.